### PR TITLE
feat: Create Cloudflare Worker for gflow D1 database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,62 @@
+# gflow-worker
+
+This is a Cloudflare Worker that provides an API for storing and retrieving tick data in a Cloudflare D1 database.
+
+## Prerequisites
+
+Before you begin, ensure you have the following installed:
+
+- [Node.js and npm](https://nodejs.org/)
+- [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
+
+## Setup
+
+1.  **Clone the repository or download the files.**
+
+2.  **Install dependencies:**
+    At present, this project has no external dependencies that need to be installed via npm.
+
+3.  **Configure your D1 Database:**
+    Open the `wrangler.toml` file. You need to replace the placeholder for `database_id` with your actual D1 database ID. You can find this by running the following command:
+
+    ```bash
+    npx wrangler d1 info gflow
+    ```
+
+    This command will output information about your `gflow` database, including the `uuid` which is your `database_id`.
+
+## Deployment
+
+To deploy the worker to your Cloudflare account, run the following command:
+
+```bash
+npx wrangler deploy
+```
+
+This will publish your worker and it will be accessible at the URL provided in the command's output.
+
+## Usage
+
+Once deployed, you can interact with the worker using any HTTP client, such as `curl`.
+
+### Saving Data (POST)
+
+To save a JSON payload, send a `POST` request to the worker's URL. The worker will automatically determine the `day` from the maximum `time` in the payload.
+
+```bash
+curl -X POST <YOUR_WORKER_URL> \
+-H "Content-Type: application/json" \
+-d @szo.json
+```
+
+Replace `<YOUR_WORKER_URL>` with the actual URL of your deployed worker. The `szo.json` file should be in the same directory where you are running the command.
+
+### Retrieving Data (GET)
+
+To retrieve the stored ticks for a specific day, send a `GET` request with a `day` query parameter.
+
+```bash
+curl "<YOUR_WORKER_URL>?day=2025-09-08"
+```
+
+Replace `<YOUR_WORKER_URL>` with your worker's URL and adjust the `day` parameter as needed. This will return the full JSON payload that was saved for that day.

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,77 @@
+export default {
+  async fetch(request, env) {
+    const { method } = request;
+
+    if (method === "POST") {
+      return handlePost(request, env);
+    }
+
+    if (method === "GET") {
+      return handleGet(request, env);
+    }
+
+    return new Response("Method Not Allowed", { status: 405 });
+  },
+};
+
+async function handlePost(request, env) {
+  try {
+    const json = await request.json();
+    const ticks = JSON.stringify(json);
+
+    const maxTime = Object.values(json).reduce((max, { time }) => {
+      return time > max ? time : max;
+    }, 0);
+
+    if (maxTime === 0) {
+      return new Response("Invalid JSON payload: 'time' field not found or is 0.", { status: 400 });
+    }
+
+    const date = new Date(maxTime);
+    const day = date.toISOString().slice(0, 10);
+
+    const { success } = await env.DB.prepare(
+      "INSERT INTO full_tick (day, ticks) VALUES (?, ?)"
+    )
+      .bind(day, ticks)
+      .run();
+
+    if (success) {
+      return new Response(`Data for day ${day} saved successfully.`, { status: 201 });
+    } else {
+      return new Response("Failed to save data.", { status: 500 });
+    }
+  } catch (e) {
+    return new Response(e.message, { status: 500 });
+  }
+}
+
+async function handleGet(request, env) {
+  const { searchParams } = new URL(request.url);
+  const day = searchParams.get("day");
+
+  if (!day) {
+    return new Response("'day' query parameter is required.", { status: 400 });
+  }
+
+  try {
+    const { results } = await env.DB.prepare(
+      "SELECT ticks FROM full_tick WHERE day = ?"
+    )
+      .bind(day)
+      .all();
+
+    if (results && results.length > 0) {
+      // Assuming 'ticks' is stored as a JSON string, we return it directly.
+      const ticks = results[0].ticks;
+      return new Response(ticks, {
+        headers: { "Content-Type": "application/json" },
+        status: 200,
+      });
+    } else {
+      return new Response(`No data found for day: ${day}`, { status: 404 });
+    }
+  } catch (e) {
+    return new Response(e.message, { status: 500 });
+  }
+}

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,10 @@
+name = "gflow-worker"
+main = "src/index.js"
+compatibility_date = "2023-10-30"
+
+[[d1_databases]]
+binding = "DB" # This is the binding name used in the worker script (env.DB)
+database_name = "gflow"
+# IMPORTANT: You need to replace the following line with your actual D1 database ID.
+# You can find the ID by running the command: `npx wrangler d1 info gflow`
+database_id = "your-database-id-goes-here"


### PR DESCRIPTION
This commit introduces a Cloudflare Worker to interact with a D1 database named 'gflow'.

The worker provides two endpoints:
- POST /: Accepts a JSON payload, finds the maximum 'time' value, and stores the entire payload in the 'full_tick' table. The 'day' is derived from the maximum timestamp.
- GET /?day=<date>: Retrieves the stored JSON payload for the specified day.

The implementation includes the worker script, a `wrangler.toml` configuration file with a placeholder for the database ID, and a `README.md` with setup and usage instructions.