### PR TITLE
feat: Default to today's date in GET requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,5 @@ curl "<YOUR_WORKER_URL>?day=2025-09-08"
 ```
 
 Replace `<YOUR_WORKER_URL>` with your worker's URL and adjust the `day` parameter as needed. This will return the full JSON payload that was saved for that day.
+
+If the `day` parameter is not provided, the worker will automatically query for the current day's data based on the UTC+8 timezone.

--- a/README.md
+++ b/README.md
@@ -62,3 +62,6 @@ curl "<YOUR_WORKER_URL>?day=2025-09-08"
 Replace `<YOUR_WORKER_URL>` with your worker's URL and adjust the `day` parameter as needed. This will return the full JSON payload that was saved for that day.
 
 If the `day` parameter is not provided, the worker will automatically query for the current day's data based on the UTC+8 timezone.
+```bash
+curl "<YOUR_WORKER_URL>"
+```

--- a/src/index.js
+++ b/src/index.js
@@ -48,10 +48,14 @@ async function handlePost(request, env) {
 
 async function handleGet(request, env) {
   const { searchParams } = new URL(request.url);
-  const day = searchParams.get("day");
+  let day = searchParams.get("day");
 
   if (!day) {
-    return new Response("'day' query parameter is required.", { status: 400 });
+    // If day is blank, query for today's data in UTC+8
+    const now = new Date();
+    const utc8Offset = 8 * 60 * 60 * 1000;
+    const utc8Now = new Date(now.getTime() + utc8Offset);
+    day = utc8Now.toISOString().slice(0, 10);
   }
 
   try {


### PR DESCRIPTION
This commit updates the Cloudflare Worker to default to today's date in the UTC+8 timezone when the 'day' parameter is not provided in a GET request.

The `handleGet` function in `src/index.js` has been modified to include this new logic. The `README.md` has also been updated to reflect this change in the API behavior.