### PR TITLE
feat: Implement upsert logic for POST requests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -37,7 +37,8 @@ async function handlePost(request, env) {
     const day = formatter.format(new Date(maxTime));
 
     const { success } = await env.DB.prepare(
-      "INSERT INTO full_tick (day, ticks) VALUES (?, ?)"
+      `INSERT INTO full_tick (day, ticks) VALUES (?, ?)
+       ON CONFLICT(day) DO UPDATE SET ticks=excluded.ticks`
     )
       .bind(day, ticks)
       .run();


### PR DESCRIPTION
This commit updates the `handlePost` function to perform an "upsert" (update or insert) operation when saving data to the D1 database.

The SQL statement has been changed to use `INSERT ... ON CONFLICT(day) DO UPDATE`, which ensures that if a record for a given day already exists, it is updated with the new `ticks` data instead of creating a duplicate entry. This makes the `day` field effectively unique.